### PR TITLE
Isomorphic Fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,5 @@
     "jest": "^29.3.0",
     "ts-jest": "^29.0.3",
     "typescript": "^4.8.4"
-  },
-  "dependencies": {
-    "node-fetch": "^3.3.2"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ export class Ollama {
 
 		let f: Fetch | null = null;
 
-		if (config?.fetch) {
+		if (config?.fetch != null) {
 			f = config.fetch;
 		} else if (typeof fetch !== "undefined") {
 			f = fetch;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,5 +1,8 @@
+export type Fetch = typeof fetch
+
 export interface Config {
-	address: string
+	address: string,
+	fetch?: Fetch
 }
 
 export interface ModelParameters {


### PR DESCRIPTION
I have removed `node-fetch` in favor of the default fetch implementation or `window.fetch` making it compatible in both nodejs and the browser.

There is also the ability to pass a custom fetch method if you are in an environment where both `window.fetch` and global `fetch` is undefined such as older versions of nodejs:

```javascript
import { Ollama } from "ollama";
import fetch from "node-fetch";

const ollama = new Ollama({ fetch });
```